### PR TITLE
Modify harmony image not to delete states

### DIFF
--- a/relayer/chains/harmony/chain.go
+++ b/relayer/chains/harmony/chain.go
@@ -166,7 +166,11 @@ func (c *Chain) StartEventListener(dst core.ChainI, strategy core.StrategyI) {
 
 // QueryClientConsensusState retrevies the latest consensus state for a client in state at a given height
 func (c *Chain) QueryClientConsensusState(height int64, dstClientConsHeight ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error) {
-	s, found, err := c.ibcHost.GetConsensusState(c.CallOpts(context.Background(), height), c.pathEnd.ClientID, dstClientConsHeight.GetRevisionHeight())
+	dstH := ibchost.HeightData{
+		RevisionNumber: dstClientConsHeight.GetRevisionNumber(),
+		RevisionHeight: dstClientConsHeight.GetRevisionHeight(),
+	}
+	s, found, err := c.ibcHost.GetConsensusState(c.CallOpts(context.Background(), height), c.pathEnd.ClientID, dstH)
 	if err != nil {
 		return nil, err
 	} else if !found {

--- a/relayer/chains/harmony/tx.go
+++ b/relayer/chains/harmony/tx.go
@@ -97,11 +97,15 @@ func (c *Chain) TxCreateClient(msg *clienttypes.MsgCreateClient) (*harmonytypes.
 	if err != nil {
 		return nil, err
 	}
+	latestHeight := clientState.GetLatestHeight()
 	log.Printf("TxCreateClient: ClientType: %+v, Height: %+v\n", clientState.ClientType(),
-		clientState.GetLatestHeight().GetRevisionHeight())
+		latestHeight.GetRevisionHeight())
 	return c.txIbcHandler(methodCreateClient, ibchandler.IBCMsgsMsgCreateClient{
-		ClientType:          clientState.ClientType(),
-		Height:              clientState.GetLatestHeight().GetRevisionHeight(),
+		ClientType: clientState.ClientType(),
+		Height: ibchandler.HeightData{
+			RevisionNumber: latestHeight.GetRevisionNumber(),
+			RevisionHeight: latestHeight.GetRevisionHeight(),
+		},
 		ClientStateBytes:    clientStateBytes,
 		ConsensusStateBytes: consensusStateBytes,
 	})
@@ -153,8 +157,8 @@ func (c *Chain) TxConnectionOpenTry(msg *conntypes.MsgConnectionOpenTry) (*harmo
 		ProofInit:            msg.ProofInit,
 		ProofClient:          msg.ProofClient,
 		ProofConsensus:       msg.ProofConsensus,
-		ProofHeight:          msg.ProofHeight.RevisionHeight,
-		ConsensusHeight:      msg.ConsensusHeight.RevisionHeight,
+		ProofHeight:          ibchandler.HeightData(msg.ProofHeight),
+		ConsensusHeight:      ibchandler.HeightData(msg.ConsensusHeight),
 	})
 }
 
@@ -174,8 +178,8 @@ func (c *Chain) TxConnectionOpenAck(msg *conntypes.MsgConnectionOpenAck) (*harmo
 		ProofTry:                 msg.ProofTry,
 		ProofClient:              msg.ProofClient,
 		ProofConsensus:           msg.ProofConsensus,
-		ProofHeight:              msg.ProofHeight.RevisionHeight,
-		ConsensusHeight:          msg.ConsensusHeight.RevisionHeight,
+		ProofHeight:              ibchandler.HeightData(msg.ProofHeight),
+		ConsensusHeight:          ibchandler.HeightData(msg.ConsensusHeight),
 	})
 }
 
@@ -183,7 +187,7 @@ func (c *Chain) TxConnectionOpenConfirm(msg *conntypes.MsgConnectionOpenConfirm)
 	return c.txIbcHandler(methodConnectionOpenConfirm, ibchandler.IBCMsgsMsgConnectionOpenConfirm{
 		ConnectionId: msg.ConnectionId,
 		ProofAck:     msg.ProofAck,
-		ProofHeight:  msg.ProofHeight.RevisionHeight,
+		ProofHeight:  ibchandler.HeightData(msg.ProofHeight),
 	})
 }
 
@@ -213,7 +217,7 @@ func (c *Chain) TxChannelOpenTry(msg *chantypes.MsgChannelOpenTry) (*harmonytype
 		},
 		CounterpartyVersion: msg.CounterpartyVersion,
 		ProofInit:           msg.ProofInit,
-		ProofHeight:         msg.ProofHeight.RevisionHeight,
+		ProofHeight:         ibchandler.HeightData(msg.ProofHeight),
 	})
 }
 
@@ -224,7 +228,7 @@ func (c *Chain) TxChannelOpenAck(msg *chantypes.MsgChannelOpenAck) (*harmonytype
 		CounterpartyVersion:   msg.CounterpartyVersion,
 		CounterpartyChannelId: msg.CounterpartyChannelId,
 		ProofTry:              msg.ProofTry,
-		ProofHeight:           msg.ProofHeight.RevisionHeight,
+		ProofHeight:           ibchandler.HeightData(msg.ProofHeight),
 	})
 }
 
@@ -233,7 +237,7 @@ func (c *Chain) TxChannelOpenConfirm(msg *chantypes.MsgChannelOpenConfirm) (*har
 		PortId:      msg.PortId,
 		ChannelId:   msg.ChannelId,
 		ProofAck:    msg.ProofAck,
-		ProofHeight: msg.ProofHeight.RevisionHeight,
+		ProofHeight: ibchandler.HeightData(msg.ProofHeight),
 	})
 }
 
@@ -250,7 +254,7 @@ func (c *Chain) TxRecvPacket(msg *chantypes.MsgRecvPacket) (*harmonytypes.Transa
 			TimeoutTimestamp:   msg.Packet.TimeoutTimestamp,
 		},
 		Proof:       msg.ProofCommitment,
-		ProofHeight: msg.ProofHeight.RevisionHeight,
+		ProofHeight: ibchandler.HeightData(msg.ProofHeight),
 	})
 }
 
@@ -268,7 +272,7 @@ func (c *Chain) TxAcknowledgement(msg *chantypes.MsgAcknowledgement) (*harmonyty
 		},
 		Acknowledgement: msg.Acknowledgement,
 		Proof:           msg.ProofAcked,
-		ProofHeight:     msg.ProofHeight.RevisionHeight,
+		ProofHeight:     ibchandler.HeightData(msg.ProofHeight),
 	})
 }
 

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -3,16 +3,21 @@ module github.com/datachainlab/harmony-cosmos-bridge-demo/relayer
 go 1.16
 
 require (
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cosmos/cosmos-sdk v0.43.0-beta1
+	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go v1.0.0-beta1
 	github.com/ethereum/go-ethereum v1.9.25
 	github.com/gogo/protobuf v1.3.3
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/harmony-one/go-sdk v1.2.8
 	github.com/harmony-one/harmony v1.10.3-0.20211125131737-65614950c7f8
-	github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20211102033703-b1c507b339f0
+	github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220225061426-1449d800e413
 	github.com/hyperledger-labs/yui-relayer v0.1.1-0.20211209032245-495b5eed40e2
 	github.com/spf13/cobra v1.1.3
+	github.com/spf13/viper v1.7.1
+	github.com/tendermint/tendermint v0.34.10
+	github.com/tendermint/tm-db v0.6.4
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/valyala/fasthttp v1.4.0 // indirect
 )

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -241,6 +241,7 @@ github.com/datachainlab/go-sdk v1.2.9-0.20220106070458-8ce5f5c807b2 h1:Do9dhrQ1U
 github.com/datachainlab/go-sdk v1.2.9-0.20220106070458-8ce5f5c807b2/go.mod h1:OSUd1JwdnT9aY0LZJ41esLwH+LnHFNAc4kOFbwqJJDQ=
 github.com/datachainlab/ibc-mock-client v0.0.0-20210801010718-05f8b1087574 h1:5m6ylWxSPVPawO7yEdvxjeKixNN4X2ueYs7g+i9JGTM=
 github.com/datachainlab/ibc-mock-client v0.0.0-20210801010718-05f8b1087574/go.mod h1:yz5E2DpB3FJZZjagC4HcW51km5HesF1tFQRr6k0HQvA=
+github.com/datachainlab/solidity-protobuf/protobuf-solidity/src/protoc/go v0.0.0-20211215073805-59460caf6e59/go.mod h1:qEfy4NhH1wQB+j56MqpQGJMDX4DS56hNnF535upHygI=
 github.com/dave/dst v0.23.1/go.mod h1:LjPcLEauK4jC5hQ1fE/wr05O41zK91Pr4Qs22Ljq7gs=
 github.com/dave/gopackages v0.0.0-20170318123100-46e7023ec56e/go.mod h1:i00+b/gKdIDIxuLDFob7ustLAVqhsZRk2qVZrArELGQ=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -630,8 +631,9 @@ github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
 github.com/hyperledger-labs/yui-corda-ibc/go v0.0.0-20210811021327-6987ac24cf84/go.mod h1:TLUR8B4T2bysDITKnWwtswpVVCIBrnmPZoP0OpAUbio=
 github.com/hyperledger-labs/yui-fabric-ibc v0.2.0/go.mod h1:0ey1+ANFpyz+8m9e7XqFk9+75VsECKBWPPp4Yf3cTZI=
-github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20211102033703-b1c507b339f0 h1:xqDAwtF5M12WLVXM80E4Sqla+7iTC+EJm+utk4iCJTw=
 github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20211102033703-b1c507b339f0/go.mod h1:Y3rEZX46slCFPSXzTRZsbj6F3OgbM+6VvDnnUBmi2mI=
+github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220225061426-1449d800e413 h1:vo3NDUMI8CC7sixzScPNZB6eA28D0D/iIGRjMtXxqaY=
+github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220225061426-1449d800e413/go.mod h1:9kttuiA6q8N9dqeyTWuT53krR0ShxMxDM8EetVC3gKI=
 github.com/hyperledger-labs/yui-relayer v0.1.1-0.20211209032245-495b5eed40e2 h1:sD9rHvfNGRTiNRdAbIDIUwZw5zN8CwRl60vUfN87oyc=
 github.com/hyperledger-labs/yui-relayer v0.1.1-0.20211209032245-495b5eed40e2/go.mod h1:zXM42GjEBT82RhJP6Z1jCMO1O24rvqBmZHWYLn5eCdg=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20200416031218-eff2f9306191/go.mod h1:SyW8QL0YfvUw0KyQ9oDA9elPRaEKdNl7O8wIApPCQlw=
@@ -1971,8 +1973,9 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.25.1-0.20200805231151-a709e31e5d12/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/bsm/ratelimit.v1 v1.0.0-20160220154919-db14e161995a/go.mod h1:KF9sEfUPAXdG8Oev9e99iLGnl2uJMjc5B+4y3O7x610=

--- a/tests/cases/tm2harmony/Makefile
+++ b/tests/cases/tm2harmony/Makefile
@@ -32,7 +32,7 @@ network-harmony-down:
 test:
 	./scripts/fixture
 	./scripts/init-rly
-	#./scripts/handshake
+	./scripts/handshake
 	#./scripts/test-tx
 
 .PHONY: network-down

--- a/tests/cases/tm2harmony/scripts/handshake
+++ b/tests/cases/tm2harmony/scripts/handshake
@@ -22,5 +22,5 @@ $RLY paths add $CHAINID_ONE $CHAINID_TWO $PATH_NAME --file=./configs/path.json
 
 retry 5 $RLY tx clients $PATH_NAME
 retry 5 $RLY tx update-clients $PATH_NAME
-retry 5 $RLY tx connection $PATH_NAME
-retry 5 $RLY tx channel $PATH_NAME
+retry 10 $RLY tx connection $PATH_NAME
+retry 10 $RLY tx channel $PATH_NAME

--- a/tests/chains/harmony/docker/Dockerfile
+++ b/tests/chains/harmony/docker/Dockerfile
@@ -42,9 +42,11 @@ RUN curl -L -o /go/bin/hmy https://harmony.one/hmycli \
 
 WORKDIR $GOPATH/src/github.com/harmony-one/harmony-test/localnet
 
+
 COPY scripts scripts
 COPY configs configs
 
 RUN chmod +x $GOPATH/src/github.com/harmony-one/harmony-test/localnet/scripts/run-localnet.sh
 WORKDIR $GOPATH/src/github.com/harmony-one/harmony
+COPY hmyscripts/kill_node.sh ./test/
 ENTRYPOINT ["/go/src/github.com/harmony-one/harmony-test/localnet/scripts/run-localnet.sh"]

--- a/tests/chains/harmony/docker/hmyscripts/kill_node.sh
+++ b/tests/chains/harmony/docker/hmyscripts/kill_node.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+pkill -9 '^(harmony|soldier|commander|profiler|bootnode)$' | sed 's/^/Killed process: /'
+#rm -rf db-127.0.0.1-*

--- a/tests/chains/harmony/docker/scripts/run-localnet.sh
+++ b/tests/chains/harmony/docker/scripts/run-localnet.sh
@@ -34,10 +34,10 @@ function setup() {
 
 function build_and_start_localnet() {
   local localnet_log="$harmony_dir/localnet_deploy.log"
-  rm -rf "$harmony_dir/tmp_log*"
-  rm -rf "$harmony_dir/.dht*"
-  rm -f "$localnet_log"
-  rm -f "$harmony_dir/*.rlp"
+#  rm -rf "$harmony_dir/tmp_log*"
+#  rm -rf "$harmony_dir/.dht*"
+#  rm -f "$localnet_log"
+#  rm -f "$harmony_dir/*.rlp"
   pushd "$(pwd)"
   cd "$harmony_dir"
   bash ./test/deploy.sh -e -B -D 60000 "$localnet_config" 2>&1 | tee "$localnet_log"


### PR DESCRIPTION
This PR modifies the contract deployed harmony docker image to keep states.
It also updates CI to verify that an IBC handshake completes.