### PR TITLE
Use the current main branch of yui-ibc-solidity

### DIFF
--- a/contract/package-lock.json
+++ b/contract/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@datachainlab/tendermint-sol": "datachainlab/tendermint-sol#4423b99b2b3683cf05161e4e323dd7b48ee65d91",
-        "@hyperledger-labs/yui-ibc-solidity": "hyperledger-labs/yui-ibc-solidity#fedb647dbd69391c316933e4980a4aa5bfab560a"
+        "@hyperledger-labs/yui-ibc-solidity": "hyperledger-labs/yui-ibc-solidity#252e45af2470cde02deb19866dcd462af0d89e93"
       },
       "devDependencies": {
         "@harmony-js/core": "^0.1.57",
@@ -2951,8 +2951,8 @@
     "node_modules/@hyperledger-labs/yui-ibc-solidity": {
       "name": "ibc-solidity",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/hyperledger-labs/yui-ibc-solidity.git#fedb647dbd69391c316933e4980a4aa5bfab560a",
-      "integrity": "sha512-ulgmR4Hg5we0YJgvUpbbvI1yImjiZt6+l0GqG3W/au2AShEkK6NpTiQeCBsc0R5PoY+dEL3CsYKM+YQVloKCQQ==",
+      "resolved": "git+ssh://git@github.com/hyperledger-labs/yui-ibc-solidity.git#252e45af2470cde02deb19866dcd462af0d89e93",
+      "integrity": "sha512-kehqo0eKtsefsUezTCGEelrEA3tvt6oNOBeOxy8zRxjWZhiWxd7EJkGKdST54Gk53YGkqFK8iD6vuc4v/3Va7Q==",
       "hasInstallScript": true,
       "license": "Apache2.0",
       "dependencies": {
@@ -22682,9 +22682,9 @@
       }
     },
     "@hyperledger-labs/yui-ibc-solidity": {
-      "version": "git+ssh://git@github.com/hyperledger-labs/yui-ibc-solidity.git#fedb647dbd69391c316933e4980a4aa5bfab560a",
-      "integrity": "sha512-ulgmR4Hg5we0YJgvUpbbvI1yImjiZt6+l0GqG3W/au2AShEkK6NpTiQeCBsc0R5PoY+dEL3CsYKM+YQVloKCQQ==",
-      "from": "@hyperledger-labs/yui-ibc-solidity@hyperledger-labs/yui-ibc-solidity#fedb647dbd69391c316933e4980a4aa5bfab560a",
+      "version": "git+ssh://git@github.com/hyperledger-labs/yui-ibc-solidity.git#252e45af2470cde02deb19866dcd462af0d89e93",
+      "integrity": "sha512-kehqo0eKtsefsUezTCGEelrEA3tvt6oNOBeOxy8zRxjWZhiWxd7EJkGKdST54Gk53YGkqFK8iD6vuc4v/3Va7Q==",
+      "from": "@hyperledger-labs/yui-ibc-solidity@hyperledger-labs/yui-ibc-solidity#252e45af2470cde02deb19866dcd462af0d89e93",
       "requires": {
         "@truffle/hdwallet-provider": "^1.2.1",
         "ejs": "^3.1.5",

--- a/contract/package.json
+++ b/contract/package.json
@@ -6,7 +6,7 @@
     "node": "16.x"
   },
   "dependencies": {
-    "@hyperledger-labs/yui-ibc-solidity": "hyperledger-labs/yui-ibc-solidity#fedb647dbd69391c316933e4980a4aa5bfab560a",
+    "@hyperledger-labs/yui-ibc-solidity": "hyperledger-labs/yui-ibc-solidity#252e45af2470cde02deb19866dcd462af0d89e93",
     "@datachainlab/tendermint-sol": "datachainlab/tendermint-sol#4423b99b2b3683cf05161e4e323dd7b48ee65d91"
   },
   "devDependencies": {

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/harmony-one/go-sdk v1.2.8
 	github.com/harmony-one/harmony v1.10.3-0.20211125131737-65614950c7f8
-	github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220523040530-fedb647dbd69
+	github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220329081338-252e45af2470
 	github.com/hyperledger-labs/yui-relayer v0.1.1-0.20211209032245-495b5eed40e2
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -632,8 +632,8 @@ github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3
 github.com/hyperledger-labs/yui-corda-ibc/go v0.0.0-20210811021327-6987ac24cf84/go.mod h1:TLUR8B4T2bysDITKnWwtswpVVCIBrnmPZoP0OpAUbio=
 github.com/hyperledger-labs/yui-fabric-ibc v0.2.0/go.mod h1:0ey1+ANFpyz+8m9e7XqFk9+75VsECKBWPPp4Yf3cTZI=
 github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20211102033703-b1c507b339f0/go.mod h1:Y3rEZX46slCFPSXzTRZsbj6F3OgbM+6VvDnnUBmi2mI=
-github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220523040530-fedb647dbd69 h1:Lb39khFpahcKIJozfARJ1vdzYuP2MQcZNto3B3q3YcU=
-github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220523040530-fedb647dbd69/go.mod h1:9kttuiA6q8N9dqeyTWuT53krR0ShxMxDM8EetVC3gKI=
+github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220329081338-252e45af2470 h1:jgvxFNqP0C0toqNwfWWnKEFQBnlP950AT2GppZULZPk=
+github.com/hyperledger-labs/yui-ibc-solidity v0.0.0-20220329081338-252e45af2470/go.mod h1:9kttuiA6q8N9dqeyTWuT53krR0ShxMxDM8EetVC3gKI=
 github.com/hyperledger-labs/yui-relayer v0.1.1-0.20211209032245-495b5eed40e2 h1:sD9rHvfNGRTiNRdAbIDIUwZw5zN8CwRl60vUfN87oyc=
 github.com/hyperledger-labs/yui-relayer v0.1.1-0.20211209032245-495b5eed40e2/go.mod h1:zXM42GjEBT82RhJP6Z1jCMO1O24rvqBmZHWYLn5eCdg=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20200416031218-eff2f9306191/go.mod h1:SyW8QL0YfvUw0KyQ9oDA9elPRaEKdNl7O8wIApPCQlw=


### PR DESCRIPTION
This modifies to use the current main branch of yui-ibc-solidity.

There was a difference between the code generated on hand and the above code during development. However, I saw that the execution of migration caused the difference, and as a result, it seems to work with the main branch as it is.