### PR TITLE
remove settings for using private module

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,14 +38,7 @@ jobs:
       - name: Build harmony libs
         if: steps.cache-harmony-libs.outputs.cache-hit != 'true'
         run: make -C relayer harmony-libs
-      # TODO remove when the private repo becomes public
-      - name: Git config for private repository
-        env:
-          PAT: ${{ secrets.PAT }}
-        run: git config --global url."https://$PAT:x-oauth-basic@github.com/".insteadOf "https://github.com/"
       - name: Build
-        env:
-          GOPRIVATE: github.com/datachainlab/ibc-harmony-client
         run: make -C relayer build
       - name: Save relayer binary cache
         uses: actions/cache@v2
@@ -67,9 +60,6 @@ jobs:
       - name: Build docker images
         if: steps.cache-docker-tendermint.outputs.cache-hit != 'true'
         working-directory: ./tests/chains/tendermint
-        env:
-          USERNAME: ${{ secrets.USERNAME }}
-          PAT: ${{ secrets.PAT }}
         run: |
           make docker-image
       - name: Save docker images

--- a/tests/chains/tendermint/Dockerfile
+++ b/tests/chains/tendermint/Dockerfile
@@ -20,14 +20,6 @@ RUN git clone https://github.com/harmony-one/bls.git -b ${BLS_TAG} --depth 1 \
 WORKDIR /root
 COPY ./ ./
 
-# TODO remove
-# for private repo
-ARG USERNAME
-ARG PAT
-ARG GOPRIVATE=github.com/datachainlab/ibc-harmony-client
-RUN echo "machine github.com login ${USERNAME} password ${PAT}" > /root/.netrc \
-    && chmod 600 /root/.netrc
-
 RUN source ./scripts/setup_bls_build_flags.sh \
     && go build -mod=readonly -o ./build/simd ./simapp/simd
 

--- a/tests/chains/tendermint/Makefile
+++ b/tests/chains/tendermint/Makefile
@@ -9,12 +9,9 @@ build:
 	. ./scripts/setup_bls_build_flags.sh && \
 	go build -o ./build/simd ./simapp/simd
 
-# TODO remove build args such as PAT, USERNAME
 .PHONY: docker-image
 docker-image:
 	$(DOCKER_BUILD) \
 		--build-arg CHAINID=ibc0 \
 		--build-arg BLS_TAG=v0.0.6 \
-		--build-arg PAT=${PAT} \
-		--build-arg USERNAME=${USERNAME} \
 		--tag="$(DOCKER_REPO)tendermint-chain:$(DOCKER_TAG)" .


### PR DESCRIPTION
Since our harmony client repository https://github.com/datachainlab/ibc-harmony-client is now public, some settings are no longer necessary.
This PR removes those old settings.